### PR TITLE
Fix compilation error with ESP-IDF v5.1.1

### DIFF
--- a/components/LovyanGFX/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/components/LovyanGFX/src/lgfx/v1/platforms/esp32/common.cpp
@@ -645,7 +645,12 @@ namespace lgfx
         cmd_val |= (1 << 10); // ACK_VALUE (set NACK)
       }
 #if defined (CONFIG_IDF_TARGET_ESP32S3)
+ #if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 3) && ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 1, 0)) \
+  || (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 1) && ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 2, 0))
+      (&dev->comd[0])[index].val = cmd_val;
+ #else
       (&dev->comd0)[index].val = cmd_val;
+ #endif
 #else
       dev->command[index].val = cmd_val;
 #endif


### PR DESCRIPTION
This fix is taken from https://github.com/lovyan03/LovyanGFX/blob/develop/src/lgfx/v1/platforms/esp32/common.cpp#L825-L830