### PR TITLE
Add missing inclusion of `<cstdint>`.

### DIFF
--- a/components/LovyanGFX/src/lgfx/v1/panel/Panel_M5HDMI.cpp
+++ b/components/LovyanGFX/src/lgfx/v1/panel/Panel_M5HDMI.cpp
@@ -15,6 +15,7 @@ Contributors:
  [mongonta0716](https://github.com/mongonta0716)
  [tobozo](https://github.com/tobozo)
 /----------------------------------------------------------------------------*/
+#include <cstdint>
 #if defined (ESP_PLATFORM)
 #include <sdkconfig.h>
 

--- a/components/LovyanGFX/src/lgfx/v1/panel/Panel_M5HDMI.hpp
+++ b/components/LovyanGFX/src/lgfx/v1/panel/Panel_M5HDMI.hpp
@@ -17,6 +17,7 @@ Contributors:
 /----------------------------------------------------------------------------*/
 #pragma once
 
+#include <cstdint>
 #include "Panel_Device.hpp"
 #include "../platforms/common.hpp"
 #include "../platforms/device.hpp"

--- a/components/LovyanGFX/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/components/LovyanGFX/src/lgfx/v1/platforms/esp32/common.cpp
@@ -15,6 +15,7 @@ Contributors:
  [mongonta0716](https://github.com/mongonta0716)
  [tobozo](https://github.com/tobozo)
 /----------------------------------------------------------------------------*/
+#include <cstdint>
 #if defined (ESP_PLATFORM)
 #include <sdkconfig.h>
 

--- a/main/hal/rtc/hal_rtc.hpp
+++ b/main/hal/rtc/hal_rtc.hpp
@@ -9,6 +9,7 @@
  * 
  */
 #pragma once
+#include <cstdint>
 #include <driver/i2c.h>
 #include <esp_log.h>
 #include <ctime>


### PR DESCRIPTION
Fixes missing include statements.

This applies the changes suggested in https://github.com/m5stack/M5Dial-UserDemo/issues/15#issue-2328485079

Resolves #15 